### PR TITLE
Update activesupport and activemodel to 5

### DIFF
--- a/xdr.gemspec
+++ b/xdr.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "~> 4"
-  spec.add_dependency "activemodel", "~> 4"
+  spec.add_dependency "activesupport", "~> 5"
+  spec.add_dependency "activemodel", "~> 5"
   spec.add_dependency "backports", "~> 3.6"
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
Fix depencies breakage caused by  https://github.com/stellar/xdrgen/commit/1ed457311b6dc81c739f3d0b526ea21d8c1edfa2

xdrgen uses version 5, so ruby-stellar-base need to use version 5, therefore ruby-xdr must use version 5 too