### PR TITLE
Fix improper decoding of padding bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ file.  This project adheres to [Semantic Versioning](http://semver.org/).
 As this project is pre 1.0, breaking changes may happen for minor version
 bumps.  A breaking change will get clearly notified in this log.
 
+## [Unreleased](https://github.com/stellar/ruby-stellar-base/compare/v1.0.0...master)
+
+### Fixed
+- Padding bytes are now properly validated when reading xdr values.  According to the XDR spec, padding must be zeros.
+
 ## [1.0.0](https://github.com/stellar/ruby-stellar-base/compare/v0.1.0...v1.0.0)
 
 ### Added

--- a/lib/xdr/concerns/reads_bytes.rb
+++ b/lib/xdr/concerns/reads_bytes.rb
@@ -5,4 +5,12 @@ module XDR::Concerns::ReadsBytes
       raise EOFError if bytes.nil? || bytes.length != length
     end
   end
+
+  def read_zeros(io, length)
+    read_bytes(io, length).each_byte do |byte|
+      raise XDR::ReadError unless byte == 0
+    end
+
+    nil
+  end
 end

--- a/lib/xdr/opaque.rb
+++ b/lib/xdr/opaque.rb
@@ -12,7 +12,7 @@ class XDR::Opaque
   def read(io)
     # read and return @length bytes
     # throw away @padding bytes
-    read_bytes(io, @length).tap{ read_bytes(io, @padding) }
+    read_bytes(io, @length).tap{ read_zeros(io, @padding) }
   end
 
   def write(val,io)

--- a/lib/xdr/string.rb
+++ b/lib/xdr/string.rb
@@ -31,6 +31,6 @@ class XDR::String
 
     # read and return length bytes
     # throw away padding bytes
-    read_bytes(io, length).tap{ read_bytes(io, padding) }
+    read_bytes(io, length).tap{ read_zeros(io, padding) }
   end
 end

--- a/lib/xdr/var_opaque.rb
+++ b/lib/xdr/var_opaque.rb
@@ -31,6 +31,6 @@ class XDR::VarOpaque
 
     # read and return length bytes
     # throw away padding bytes
-    read_bytes(io, length).tap{ read_bytes(io, padding) }
+    read_bytes(io, length).tap{ read_zeros(io, padding) }
   end
 end

--- a/spec/lib/xdr/concerns/reads_bytes_spec.rb
+++ b/spec/lib/xdr/concerns/reads_bytes_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 class TestReader
   include XDR::Concerns::ReadsBytes
   public :read_bytes
+  public :read_zeros
 end
 
 
@@ -27,5 +28,30 @@ describe XDR::Concerns::ReadsBytes, "#read_bytes"  do
   def read(str, length)
     io = StringIO.new(str)
     subject.read_bytes(io, length)
+  end
+end
+
+
+describe XDR::Concerns::ReadsBytes, "#read_zeros"  do
+  subject{ TestReader.new }
+
+  it "raises XDR::ReadError when the bytes read do not equal zero" do
+    expect{ read("\x01", 1) }.to raise_error(XDR::ReadError)
+  end
+
+  it "succeeds when all the bytes read are zero" do
+    expect{ read("\x00\x00\x00\x00", 1) }.to_not raise_error
+    expect{ read("\x00\x00\x00\x00", 2) }.to_not raise_error
+    expect{ read("\x00\x00\x00\x00", 3) }.to_not raise_error
+    expect{ read("\x00\x00\x00\x00", 4) }.to_not raise_error
+  end
+
+  it "raises EOFError when the requested length goes beyond the length of the stream" do
+    expect{ read("\x00\x00\x00\x00", 5) }.to raise_error(EOFError)
+  end
+
+  def read(str, length)
+    io = StringIO.new(str)
+    subject.read_zeros(io, length)
   end
 end

--- a/spec/lib/xdr/opaque_spec.rb
+++ b/spec/lib/xdr/opaque_spec.rb
@@ -9,6 +9,10 @@ describe XDR::Opaque, "#read" do
     expect(read("\x00\x01\x00\x00")).to eq("\x00\x01\x00")
   end
 
+  it "raises a ReadError when the padding isn't zeros" do
+    expect{ read "\x00\x00\x01\x01" }.to raise_error(XDR::ReadError)
+  end
+
   def read(str)
     io = StringIO.new(str)
     subject.read(io)

--- a/spec/lib/xdr/string_spec.rb
+++ b/spec/lib/xdr/string_spec.rb
@@ -14,6 +14,12 @@ describe XDR::String, "#read" do
     expect{ read "\x00\x00\x00\x04hiya" }.to raise_error(XDR::ReadError)
   end
 
+  it "raises a ReadError when the padding isn't zeros" do
+    expect{ read "\x00\x00\x00\x01h\x00\x00\x01" }.to raise_error(XDR::ReadError)
+    expect{ read "\x00\x00\x00\x01h\x00\x01\x00" }.to raise_error(XDR::ReadError)
+    expect{ read "\x00\x00\x00\x01h\x01\x00\x00" }.to raise_error(XDR::ReadError)
+  end
+
   def read(str)
     io = StringIO.new(str)
     subject.read(io)

--- a/spec/lib/xdr/var_opaque_spec.rb
+++ b/spec/lib/xdr/var_opaque_spec.rb
@@ -15,6 +15,13 @@ describe XDR::VarOpaque, "#read" do
     expect{ read "\x00\x00\x00\x03\x00\x00\x00\x00" }.to raise_error(XDR::ReadError)
   end
 
+
+  it "raises a ReadError when the padding isn't zeros" do
+    expect{ read "\x00\x00\x00\x01\x01\x00\x00\x01" }.to raise_error(XDR::ReadError)
+    expect{ read "\x00\x00\x00\x01\x01\x00\x01\x00" }.to raise_error(XDR::ReadError)
+    expect{ read "\x00\x00\x00\x01\x01\x01\x00\x00" }.to raise_error(XDR::ReadError)
+  end
+
   def read(str)
     io = StringIO.new(str)
     subject.read(io)


### PR DESCRIPTION
This commit ensures that xdr values are properly padded with zero bytes.