### PR TITLE
Add encoding parameter to Union#to_xdr

### DIFF
--- a/lib/xdr/concerns/converts_to_xdr.rb
+++ b/lib/xdr/concerns/converts_to_xdr.rb
@@ -45,7 +45,7 @@ module XDR::Concerns::ConvertsToXDR
       tap{|io| write(val, io)}.
       string.force_encoding("ASCII-8BIT")
 
-    case encoding
+    case encoding.to_s
     when 'raw' ; raw
     when 'base64' ; Base64.strict_encode64(raw)
     when 'hex' ; raw.unpack("H*").first

--- a/lib/xdr/union.rb
+++ b/lib/xdr/union.rb
@@ -75,8 +75,14 @@ class XDR::Union
     set(switch, value) unless switch == :__unset__
   end
 
-  def to_xdr
-    self.class.to_xdr self
+  #
+  # Serializes struct to xdr, return a string of bytes
+  #
+  # @param format=:raw [Symbol] The encoding used for the bytes produces, one of (:raw, :hex, :base64)
+  #
+  # @return [String] The encoded bytes of this struct
+  def to_xdr(format=:raw)
+    self.class.to_xdr(self, format)
   end
 
   def set(switch, value=:void)

--- a/spec/lib/xdr/union_spec.rb
+++ b/spec/lib/xdr/union_spec.rb
@@ -186,6 +186,16 @@ describe XDR::Union, "#switch" do
   end
 end
 
+describe XDR::Union, "#to_xdr" do
+  subject { UnionSpec::Result.new(:error, "spec error") }
+
+  context "with base64 encoding" do
+    it "returns base64 encoding of union's XDR" do
+      expect(subject.to_xdr(:base64)).to eq("AAAAAQAAAApzcGVjIGVycm9yAAA=")
+    end
+  end
+end
+
 module UnionSpec
   class ResultType < XDR::Enum
     member :ok, 0


### PR DESCRIPTION
Hi there!

For some reason, `Stellar::Union#to_xdr` method doesn't accept encoding parameter, and it seems inconsistent across other XDR structures. This PR fixes that

Please let me know if there was a particular reason to implement `Stellar::Union#to_xdr` this way. And if I can improve this PR too, of course!