### PR TITLE
Fix non-bang arm accessors for XDR::Union

### DIFF
--- a/lib/xdr/union.rb
+++ b/lib/xdr/union.rb
@@ -102,14 +102,17 @@ class XDR::Union
 
   alias get value
 
-  def attribute!(attr)
-    if @arm.to_s != attr
-      raise XDR::ArmNotSetError, "#{attr} is not the set arm"
-    end
+  def attribute(attr)
+    return nil unless @arm.to_s == attr
 
     get
   end
 
+  def attribute!(attr)
+    raise XDR::ArmNotSetError, "#{attr} is not the set arm" unless @arm.to_s == attr
+
+    get
+  end
 
   #
   # Compares two unions for equality

--- a/spec/lib/xdr/union_spec.rb
+++ b/spec/lib/xdr/union_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe XDR::Union, ".read" do
   
   subject{ UnionSpec::Result }
@@ -58,16 +56,39 @@ describe XDR::Union, ".read" do
 
 end
 
-describe XDR::Union, "#attribute!" do
-  subject{ UnionSpec::Result.new(:ok) }
+describe XDR::Union, "#attribute" do
+  subject(:union) { UnionSpec::Result.new }
 
-  it "raises an ArmNotSetError when the attribute requested has not been populated" do
-    expect{ subject.message! }.to raise_error XDR::ArmNotSetError
+  it "returns nil when no arm is selected" do
+    expect(union.message).to be_nil
   end
 
-  it "returns the underyling value when the arm is populated" do
-    subject.set(:error, "it all went bad")
-    expect(subject.message!).to eq("it all went bad")
+  it "returns nil when non-matching arm is selected" do
+    union.set :ok
+    expect(union.message).to be_nil
+  end
+
+  it "returns the underyling value when the correct arm is selected" do
+    union.set :error, "it all went bad"
+    expect(union.message).to eq("it all went bad")
+  end
+end
+
+describe XDR::Union, "#attribute!" do
+  subject(:union) { UnionSpec::Result.new }
+
+  it "raises XDR::ArmNotSetError when no arm is selected" do
+    expect { union.message! }.to raise_error(XDR::ArmNotSetError)
+  end
+
+  it "raises XDR::ArmNotSetError when non-matching arm is selected" do
+    union.set :ok
+    expect { union.message! }.to raise_error(XDR::ArmNotSetError)
+  end
+
+  it "returns the underyling value when the correct arm is selected" do
+    union.set :error, "it all went bad"
+    expect(union.message!).to eq("it all went bad")
   end
 end
 


### PR DESCRIPTION
`XDR::Union` generates two accessor methods for every non-void arm, but the implementation for non-bang accessor is missing. This PR fixes that by implementing `#attribute` method, which behaves exactly like `attribute!`, except that in case of the arm mismatch it returns nil instead of raising exception.


```ruby
require "xdr"

class ResultType < XDR::Enum
  member :ok, 0
  member :err, 1
  seal
end

class Result < XDR::Union
  switch_on ResultType, :type

  switch :ok, :val
  switch :err, :message

  attribute :val, XDR::Hyper
  attribute :message, XDR::String[]
end

# bang accessors are fine
Result.new(:err, "wow").message! #=> "wow"
Result.new(:ok, 123).val         #=> 123
Result.new(:ok, 123).message!    #=> XDR::ArmNotSetError: message is not the set arm
Result.new(:err, "wow").val!     #=> XDR::ArmNotSetError: val is not the set arm

# lets try non-bang variant
Result.new(:ok, 123).val         #=> NoMethodError: undefined method `attribute' for #<Result:0x00007f93760c97a0>
Result.new(:err, "wow").val      #=> NoMethodError: undefined method `attribute' for #<Result:0x00007f93760982b8>

# with this PR merged
Result.new(:ok, 123).val         #=> 123
Result.new(:err, "wow").val      #=> nil
```


/cc @abuiles 