### PR TITLE
Fix .from_xdr encoding param to accept symbols

### DIFF
--- a/lib/xdr/concerns/converts_to_xdr.rb
+++ b/lib/xdr/concerns/converts_to_xdr.rb
@@ -5,68 +5,66 @@ module XDR::Concerns::ConvertsToXDR
 
   # 
   # Serialized the provided `val` to xdr and writes it to `io`
-  # 
+  #
+  # @abstract
   # @param val [Object] The object to serialize
-  # @param io [IO] an IO object to write to
-  # 
+  # @param io [#write] an IO object to write to
+  # @return [void]
   def write(val, io)
     raise NotImplementedError, "implement in including class"
   end
 
   # 
   # Reads from the provided IO an instance of the implementing class
-  # @param io [IO] the io to read from
-  # 
+  #
+  # @abstract
+  # @param io [#read] the io to read from
   # @return [Object] the deserialized value
   def read(io)
     raise NotImplementedError, "implement in including class"
   end
 
-  # 
   # Returns true if the value provided is compatible with this serializer class
-  # 
+  #
+  # @abstract
   # @param value [Object] the value to test
-  # 
   # @return [Boolean] true if valid, false otherwise
   def valid?(value)
     raise NotImplementedError, "implement in including class"
   end
-  
-  # 
+
   # Serialized the provided val to xdr, returning a string
   # of the serialized data
   # 
   # @param val [Object] the value to serialize
-  # 
+  # @param encoding [:raw|:hex|:base64] encode the result with specified codec
   # @return [String] the produced bytes
-  def to_xdr(val, encoding='raw')
-    raw = StringIO.
-      new.
-      tap{|io| write(val, io)}.
-      string.force_encoding("ASCII-8BIT")
+  def to_xdr(val, encoding = "raw")
+    io = StringIO.new
+    write(val, io)
+    raw = io.string.force_encoding("ASCII-8BIT")
 
-    case encoding.to_s
-    when 'raw' ; raw
-    when 'base64' ; Base64.strict_encode64(raw)
-    when 'hex' ; raw.unpack("H*").first
+    case String(encoding)
+    when "raw" then raw
+    when "hex" then raw.unpack("H*").first
+    when "base64" then Base64.strict_encode64(raw)
     else
-      raise  ArgumentError, "Invalid encoding #{encoding.inspect}: must be 'raw', 'base64', or 'hex'"
+      raise ArgumentError, "Invalid encoding #{encoding.inspect}: must be 'raw', 'base64', or 'hex'"
     end
   end
-  
-  # 
+
   # Deserializes an object from the provided string of bytes
-  # 
+  #
   # @param string [String] the bytes to read from
-  # 
+  # @param encoding [:raw|:hex|:base64] decode the input before deserialization
   # @return [Object] the deserialized value
-  def from_xdr(string, encoding='raw')
-    raw = case encoding
-          when 'raw' ; string
-          when 'base64' ; Base64.strict_decode64(string)
-          when 'hex' ; [string].pack("H*")
+  def from_xdr(string, encoding = "raw")
+    raw = case String(encoding)
+          when "raw" then string
+          when "hex" then [string].pack("H*")
+          when "base64" then Base64.strict_decode64(string)
           else
-            raise  ArgumentError, "Invalid encoding #{encoding.inspect}: must be 'raw', 'base64', or 'hex'"
+            raise ArgumentError, "Invalid encoding #{encoding.inspect}: must be 'raw', 'base64', or 'hex'"
           end
 
     io = StringIO.new(raw)
@@ -80,6 +78,7 @@ module XDR::Concerns::ConvertsToXDR
   end
 
   private
+
   def padding_for(length)
     case length % 4
     when 0 ; 0

--- a/spec/lib/xdr/concerns/converts_to_xdr_spec.rb
+++ b/spec/lib/xdr/concerns/converts_to_xdr_spec.rb
@@ -36,6 +36,11 @@ describe XDR::Concerns::ConvertsToXDR, "#to_xdr" do
       r = subject.to_xdr("\x00\x01\x02\x03", "base64")
       expect(r).to eql("AAECAw==")
     end
+
+    it "understands encoding in symbol form" do
+      r = subject.to_xdr("\x00\x01\x02\x03", :base64)
+      expect(r).to eql("AAECAw==")
+    end
   end
 end
 
@@ -58,6 +63,11 @@ describe XDR::Concerns::ConvertsToXDR, "#from_xdr" do
 
     it "decodes from base64" do
       r = subject.from_xdr("AAECAw==", "base64")
+      expect(r).to eql("\x00\x01\x02\x03")
+    end
+
+    it "understands encoding in symbol form" do
+      r = subject.from_xdr("AAECAw==", :base64)
       expect(r).to eql("\x00\x01\x02\x03")
     end
 


### PR DESCRIPTION
Update `.from_xdr(string, encoding)` to accept Ruby symbols for encoding param as well as string. Using symbols for enum-like arguments is a common idiom in Ruby, and also corresponding `#to_xdr` method does accept symbols, which makes the error in `.from_xdr` especially confusing.

/cc @abuiles 