### PR TITLE
fix: make `XDR::Option` write empty strings as values

### DIFF
--- a/lib/xdr/option.rb
+++ b/lib/xdr/option.rb
@@ -11,11 +11,11 @@ class XDR::Option
   end
 
   def write(val, io)
-    if val.present?
+    if val.nil?
+      XDR::Bool.write(false, io)
+    else
       XDR::Bool.write(true, io)
       @child_type.write(val, io)
-    else
-      XDR::Bool.write(false, io)
     end
   end
 

--- a/spec/lib/xdr/option_spec.rb
+++ b/spec/lib/xdr/option_spec.rb
@@ -22,9 +22,19 @@ describe XDR::Option, ".write" do
     expect(write(nil)).to eq_bytes("\x00\x00\x00\x00")
   end
 
-  it "raises WriteError when the provided value is non-nil bust invalid for the child type" do
-    expect { write 1.0 }.to raise_error(XDR::WriteError)
-    expect { write "hi" }.to raise_error(XDR::WriteError)
+  context "when the provided value is not nil, but invalid for the child type" do
+    it "raises WriteError " do
+      expect { write(1.0) }.to raise_error(XDR::WriteError)
+      expect { write("hi") }.to raise_error(XDR::WriteError)
+    end
+  end
+
+  context "when provided value is empty string" do
+    subject { XDR::Option[XDR::VarOpaque[64]] }
+
+    it "writes empty string" do
+      expect(write("")).to eq_bytes("\x00\x00\x00\x01\x00\x00\x00\x00")
+    end
   end
 
   def write(val)


### PR DESCRIPTION
At the moment `XDR::Option` uses `.present?` predicate to check, if value is provided. However, it denies empty strings, so we cannot create XDR options with empty string as a value. And such options can be used, for example, in Stellar `ManageData` operation. `nil` value have a special meaning there, but we may still want to have data entry with empty value. `js-xdr` seems to support it that way

This should fix https://github.com/astroband/ruby-stellar-sdk/issues/164